### PR TITLE
Update accent colors

### DIFF
--- a/common/color_definitions.scss
+++ b/common/color_definitions.scss
@@ -3,8 +3,8 @@
   --cc-card-colour: #23282D;
   --cc-custom-links-border: #fff;
   --cc-header-border: #fff;
-  --cc-link-colour: #d7fffe;
-  --cc-link-colour-hover: #accccb;
+  --cc-link-colour: #76b2ff;
+  --cc-link-colour-hover: #9ecbfb;
   --cc-topic-highlights: #333;
   --cc-topic-highlights-border: #607c98;
   --cc-moderator-highlight: #141c3a;
@@ -12,10 +12,12 @@
   --primary-medium: #ccc;
   --primary-high: #ddd;
   --primary-med-or-secondary-high: #ccc;
-  --tertiary-low: #007572;
+  --tertiary: #76b2ff;
+  --tertiary-low: #4875b0;
   --tertiary-medium: #007572;
-  --tertiary-hover: #007572;
-  --danger-hover: #f95a5c;
+  --tertiary-hover: #3a8ffc;
+  --quaternary: #76b2ff;
+  --quaternary-low: #525457;
   --danger-low-mid: rgb(141 49 50 / 70%);
   --highlight-medium: #262626;
   --wiki: var(--success);

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,8 @@
+a:hover, 
+a:visited {
+    color: var(--cc-link-colour-hover);
+}
+
 .btn:active .d-icon {
     background-color: inherit !important;
 }
@@ -68,6 +73,11 @@
 #reply-control .mini-tag-chooser,
 #reply-control #reply-title {
     background: inherit;
+}
+
+.d-editor-textarea-wrapper.in-focus {
+    border-color: var(--tertiary-low);
+    outline: none;
 }
 
 .discourse-no-touch .btn-primary:hover:disabled,


### PR DESCRIPTION
Accent color for buttons, links, and text input border changed to a shade of blue that is less blinding against the dark background.

I'm no designer, so let me know what you think, but these colors are a lot easier on my eyes -- particularly the new border highlight on the text input.  